### PR TITLE
fix: implement async processing for Instantly email_sent webhook

### DIFF
--- a/tests/integration/instantly/test_instantly_email_sent_integration.py
+++ b/tests/integration/instantly/test_instantly_email_sent_integration.py
@@ -71,6 +71,8 @@ class TestInstantlyEmailSentIntegration:
         print(f"Webhook response status: {response.status_code}")
         print(f"Webhook response: {response.json()}")
 
+        sleep(10)
+        
         # Define verification functions with retries
         print("Checking if task is complete...")
         task = self.close_api.get_task(self.test_data["task_id"])


### PR DESCRIPTION
Changes in this PR:
* wrap the logic inside `handle_instantly_email_sent()` in a new celery task to avoid the timeout error after 30s on Heroku
