### PR TITLE
WebhookEmailSentWorkflow: max retries=2

### DIFF
--- a/temporal/workflows/instantly.py
+++ b/temporal/workflows/instantly.py
@@ -29,7 +29,8 @@ class WebhookEmailSentWorkflow:
     def __init__(self) -> None:
         self._data_issue_fixed: bool = True
         self._activity_retry_policy = RetryPolicy(
-            maximum_attempts=1,
+            initial_interval=timedelta(seconds=5),
+            maximum_attempts=2,
         )
 
     @workflow.signal


### PR DESCRIPTION
Often, a stuck Workflow run due to the issue "Expected 1 lead, got 0" can progress by simply retrying:

<img width="1351" height="268" alt="Screenshot from 2025-09-08 18-41-23" src="https://github.com/user-attachments/assets/5189f0ab-46b4-4e70-a8f5-4de6fec8925b" />
