### PR TITLE
update notification recipients: remove Noura from April's team

### DIFF
--- a/blueprints/instantly.py
+++ b/blueprints/instantly.py
@@ -98,7 +98,6 @@ def determine_notification_recipients(lead_details, env_type):
             # Production: April's team
             recipients_list = [
                 "april.lowrie@whiteboardgeeks.com",
-                "noura.mahmoud@whiteboardgeeks.com",
                 "lauren.poche@whiteboardgeeks.com",
             ]
             recipients = ",".join(recipients_list)

--- a/tests/unit/instantly/test_consultant_notification.py
+++ b/tests/unit/instantly/test_consultant_notification.py
@@ -147,7 +147,7 @@ class TestConsultantNotification:
         )
 
         # April should get custom recipients in production
-        expected_recipients = "april.lowrie@whiteboardgeeks.com,noura.mahmoud@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
+        expected_recipients = "april.lowrie@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
         assert (
             recipients == expected_recipients
         ), f"Expected April's team recipients, got {recipients}"
@@ -258,7 +258,7 @@ class TestConsultantNotification:
         )
 
         # Verify the exact format and order of April's team
-        expected_recipients = "april.lowrie@whiteboardgeeks.com,noura.mahmoud@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
+        expected_recipients = "april.lowrie@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
         assert (
             recipients == expected_recipients
         ), f"April's team recipients format incorrect: {recipients}"
@@ -266,10 +266,9 @@ class TestConsultantNotification:
         # Verify all three team members are included
         recipient_list = recipients.split(",")
         assert (
-            len(recipient_list) == 3
-        ), f"Expected 3 recipients for April's team, got {len(recipient_list)}"
+            len(recipient_list) == 2
+        ), f"Expected 2 recipients for April's team, got {len(recipient_list)}"
         assert "april.lowrie@whiteboardgeeks.com" in recipient_list
-        assert "noura.mahmoud@whiteboardgeeks.com" in recipient_list
         assert "lauren.poche@whiteboardgeeks.com" in recipient_list
 
     def test_development_environment_override(self):
@@ -303,7 +302,7 @@ class TestConsultantNotification:
         recipients, error = determine_notification_recipients(
             self.april_lead_details, "production"
         )
-        expected_april_team = "april.lowrie@whiteboardgeeks.com,noura.mahmoud@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
+        expected_april_team = "april.lowrie@whiteboardgeeks.com,lauren.poche@whiteboardgeeks.com"
         assert (
             recipients == expected_april_team
         ), "April should use her team in production"


### PR DESCRIPTION
As requested by Noura this PR removes her from the recipient list that get notified on an error event in MailerAutomation.