### PR TITLE
migrate /instantly/reply_received to Temporal

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,7 +166,19 @@ jobs:
           
           # Run the integration tests for this blueprint (excluding stress tests)
           echo "Running integration tests for ${{ matrix.blueprint }} (excluding stress tests)..."
-          pytest tests/integration/${{ matrix.blueprint }} -v -m "not stress"
+
+          if [ "${{ matrix.blueprint }}" = "instantly" ]; then
+            for flag in false true; do
+              echo "Setting USE_TEMPORAL_FOR_REPLY_RECEIVED=$flag on staging app"
+              heroku config:set USE_TEMPORAL_FOR_REPLY_RECEIVED=$flag --app mailer-automation-staging
+              echo "Waiting for dynos to restart after config change..."
+              sleep 45
+              echo "Running Instantly integration tests with USE_TEMPORAL_FOR_REPLY_RECEIVED=$flag"
+              pytest tests/integration/instantly -v -rs -m "not stress"
+            done
+          else
+            pytest tests/integration/${{ matrix.blueprint }} -v -rs -m "not stress"
+          fi
           
   deploy-to-production:
     needs: blueprint-integration-tests

--- a/config.py
+++ b/config.py
@@ -1,7 +1,19 @@
 import os
+from typing import Optional
+
+
+def _str_to_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "t", "yes", "y"}
 
 
 env_type = os.getenv("ENV_TYPE", "development")
+use_temporal_for_reply_received = _str_to_bool(
+    os.getenv("USE_TEMPORAL_FOR_REPLY_RECEIVED", "false")
+)
+
 print("=== ENVIRONMENT INFO ===")
 print(f"ENV_TYPE: {env_type}")
+print(f"USE_TEMPORAL_FOR_REPLY_RECEIVED: {use_temporal_for_reply_received}")
 print("=== END ENVIRONMENT INFO ===")

--- a/temporal/activities/instantly/webhook_reply_received.py
+++ b/temporal/activities/instantly/webhook_reply_received.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+from temporalio import activity
+
+from close_utils import (
+    create_email_search_query,
+    get_lead_by_id,
+    get_sequence_subscriptions,
+    make_close_request,
+    pause_sequence_subscription,
+    search_close_leads,
+)
+from temporal.activities.instantly.webhook_add_lead import BARBARA_USER_ID
+from utils.email import send_email
+from utils.instantly_reply_received import determine_notification_recipients
+
+
+class WebhookReplyReceivedPayloadValidated(BaseModel):
+    event_type: str = Field(..., description="Type of Instantly webhook event")
+    lead_email: str = Field(..., description="Lead email address")
+    campaign_name: str = Field(..., description="Instantly campaign name")
+    reply_subject: str = Field(..., description="Reply subject")
+    reply_text: Optional[str] = Field(None, description="Plain text reply body")
+    reply_html: Optional[str] = Field(None, description="HTML reply body")
+    timestamp: str = Field(..., description="Reply timestamp")
+    email_account: str = Field(..., description="Instantly sending account")
+
+
+class AddEmailActivityToLeadArgs(BaseModel):
+    payload: WebhookReplyReceivedPayloadValidated
+
+
+class AddEmailActivityToLeadResult(BaseModel):
+    lead_id: str
+    lead_email: str
+    lead_name: str
+    lead_details: Dict[str, Any]
+    email_activity_id: str
+
+
+class PauseSequenceSubscriptionsArgs(BaseModel):
+    lead_id: str
+    lead_email: str
+
+
+class PauseSequenceSubscriptionsResult(BaseModel):
+    paused_subscriptions: List[Dict[str, Any]]
+
+
+class SendNotificationEmailArgs(BaseModel):
+    lead_id: str
+    lead_email: str
+    lead_name: str
+    campaign_name: str
+    reply_subject: str
+    reply_text: Optional[str]
+    reply_html: Optional[str]
+    env_type: str
+    paused_subscriptions: List[Dict[str, Any]]
+    lead_details: Dict[str, Any]
+    email_activity_id: str
+
+
+class SendNotificationEmailResult(BaseModel):
+    notification_status: str
+    custom_recipients_used: bool
+
+
+@activity.defn(name="reply_received_add_email_activity_to_lead")
+def add_email_activity_to_lead(args: AddEmailActivityToLeadArgs) -> AddEmailActivityToLeadResult:
+    payload = args.payload
+
+    query = create_email_search_query(payload.lead_email)
+    leads = search_close_leads(query)
+
+    if not leads:
+        raise ValueError(f"No lead found with email: {payload.lead_email}")
+
+    if len(leads) > 1:
+        raise ValueError(
+            f"Multiple leads found with email: {payload.lead_email}"
+        )
+
+    lead = leads[0]
+    lead_id = lead["id"]
+    activity.logger.info("lead_id = %s lead_email = %s", lead_id, payload.lead_email)
+
+    lead_details = get_lead_by_id(lead_id)
+    if not lead_details:
+        raise ValueError(
+            f"Could not retrieve lead details for lead ID: {lead_id}"
+        )
+
+    contact = None
+    target_email = (payload.lead_email or "").strip().lower()
+    for contact_candidate in lead_details.get("contacts", []):
+        for email_entry in contact_candidate.get("emails", []):
+            email_value = (
+                (email_entry.get("email") or email_entry.get("address") or "")
+                .strip()
+                .lower()
+            )
+            if email_value == target_email and target_email:
+                contact = contact_candidate
+                break
+        if contact:
+            break
+
+    if not contact:
+        contact_debug = [
+            {
+                "contact_id": c.get("id"),
+                "emails": [
+                    (e.get("email") or e.get("address") or "").strip()
+                    for e in c.get("emails", [])
+                ],
+            }
+            for c in lead_details.get("contacts", [])
+        ]
+        activity.logger.error(
+            "contact_lookup_failed lead_id=%s lead_email=%s contacts=%s",
+            lead_id,
+            payload.lead_email,
+            contact_debug,
+        )
+        raise ValueError(f"No contact found with email: {payload.lead_email}")
+
+    email_data = {
+        "contact_id": contact["id"],
+        "user_id": BARBARA_USER_ID,
+        "lead_id": lead_id,
+        "direction": "incoming",
+        "created_by": None,
+        "date_created": payload.timestamp.replace("Z", "+00:00").replace("T", "T"),
+        "subject": payload.reply_subject,
+        "sender": payload.lead_email,
+        "to": [payload.email_account],
+        "bcc": [],
+        "cc": [],
+        "status": "inbox",
+        "body_text": payload.reply_text or "",
+        "body_html": payload.reply_html or "",
+        "attachments": [],
+        "template_id": None,
+    }
+
+    email_url = "https://api.close.com/api/v1/activity/email/"
+    email_response = make_close_request("post", email_url, json=email_data)
+    email_activity_id = email_response.json().get("id")
+
+    lead_name = lead_details.get("name", "Unknown")
+
+    return AddEmailActivityToLeadResult(
+        lead_id=lead_id,
+        lead_email=payload.lead_email,
+        lead_name=lead_name,
+        lead_details=lead_details,
+        email_activity_id=email_activity_id,
+    )
+
+
+@activity.defn(name="reply_received_pause_sequence_subscriptions")
+def pause_sequence_subscriptions(
+    args: PauseSequenceSubscriptionsArgs,
+) -> PauseSequenceSubscriptionsResult:
+    subscriptions = get_sequence_subscriptions(lead_id=args.lead_id)
+    paused: List[Dict[str, Any]] = []
+
+    for subscription in subscriptions:
+        if subscription.get("status") != "active":
+            continue
+
+        subscription_id = subscription.get("id")
+        result = pause_sequence_subscription(
+            subscription_id,
+            status_reason="replied",
+        )
+
+        if not result:
+            continue
+
+        paused.append(
+            {
+                "subscription_id": subscription_id,
+                "sequence_id": subscription.get("sequence_id"),
+                "sequence_name": subscription.get("sequence_name", "Unknown"),
+            }
+        )
+        activity.logger.info(
+            "sequence_paused subscription_id=%s lead_id=%s lead_email=%s",
+            subscription_id,
+            args.lead_id,
+            args.lead_email,
+        )
+
+    return PauseSequenceSubscriptionsResult(paused_subscriptions=paused)
+
+
+@activity.defn(name="reply_received_send_notification_email")
+def send_notification_email(
+    args: SendNotificationEmailArgs,
+) -> SendNotificationEmailResult:
+    env_type = args.env_type
+    reply_html = args.reply_html
+    reply_text = args.reply_text
+
+    custom_recipients, consultant_error = determine_notification_recipients(
+        args.lead_details, env_type
+    )
+
+    if consultant_error:
+        raise ValueError(consultant_error)
+
+    timestamp_now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    notification_html = f"""
+        <h2>Instantly Email Reply Received</h2>
+        <p>A reply has been received from an Instantly email campaign.</p>
+        
+        <h3>Details:</h3>
+        <ul>
+            <li><strong>Lead:</strong> {args.lead_name}</li>
+            <li><strong>Lead Email:</strong> {args.lead_email}</li>
+            <li><strong>Campaign:</strong> {args.campaign_name}</li>
+            <li><strong>Subject:</strong> {args.reply_subject}</li>
+            <li><strong>Environment:</strong> {env_type}</li>
+            <li><strong>Time:</strong> {timestamp_now}</li>
+        </ul>
+        
+        <h3>Reply Content:</h3>
+        <div style="border: 1px solid #ddd; padding: 15px; margin: 10px 0; background-color: #f9f9f9;">
+            {reply_html or reply_text or "No content available"}
+        </div>
+    """
+
+    if args.paused_subscriptions:
+        notification_html += """
+            <h3>Sequences Paused:</h3>
+            <ul>
+        """
+        for sub in args.paused_subscriptions:
+            notification_html += (
+                f"<li>{sub.get('sequence_name', 'Unknown Sequence')} "
+                f"(ID: {sub.get('sequence_id')})</li>"
+            )
+        notification_html += "</ul>"
+
+    notification_html += (
+        f'<p><a href="https://app.close.com/lead/{args.lead_id}/" '
+        f'style="padding: 10px 15px; background-color: #4CAF50; color: white; '
+        f'text-decoration: none; border-radius: 4px; display: inline-block; margin-top: 10px;">'
+        f"View Lead in Close</a></p>"
+    )
+
+    text_content = (
+        "Instantly Reply Received\n\n"
+        f"Lead: {args.lead_name}\n"
+        f"Email: {args.lead_email}\n"
+        f"Campaign: {args.campaign_name}\n"
+        f"Subject: {args.reply_subject}\n"
+        f"Environment: {env_type}\n"
+        f"Time: {timestamp_now}"
+    )
+
+    if args.paused_subscriptions:
+        text_content += "\n\nSequences Paused:"
+        for sub in args.paused_subscriptions:
+            text_content += (
+                f"\n- {sub.get('sequence_name', 'Unknown Sequence')} "
+                f"(ID: {sub.get('sequence_id')})"
+            )
+
+    email_kwargs: Dict[str, Any] = {
+        "subject": f"Instantly Reply: {args.reply_subject} from {args.lead_name}",
+        "body": notification_html,
+        "text_content": text_content,
+    }
+
+    if custom_recipients:
+        email_kwargs["recipients"] = custom_recipients
+        activity.logger.info(
+            "using_custom_recipients lead_id=%s recipients=%s",
+            args.lead_id,
+            custom_recipients,
+        )
+
+    notification_status = "unknown"
+    try:
+        notification_result = send_email(**email_kwargs)
+        notification_status = notification_result.get("status", "unknown")
+        activity.logger.info(
+            "notification_email_sent status=%s message_id=%s",
+            notification_status,
+            notification_result.get("message_id"),
+        )
+    except Exception as email_error:  # pragma: no cover - defensive logging
+        activity.logger.error(
+            "gmail_notification_failed error=%s",
+            str(email_error),
+        )
+        notification_status = "error"
+
+    return SendNotificationEmailResult(
+        notification_status=notification_status,
+        custom_recipients_used=bool(custom_recipients),
+    )
+
+
+__all__ = [
+    "AddEmailActivityToLeadArgs",
+    "AddEmailActivityToLeadResult",
+    "PauseSequenceSubscriptionsArgs",
+    "PauseSequenceSubscriptionsResult",
+    "SendNotificationEmailArgs",
+    "SendNotificationEmailResult",
+    "WebhookReplyReceivedPayloadValidated",
+    "add_email_activity_to_lead",
+    "pause_sequence_subscriptions",
+    "send_notification_email",
+]

--- a/temporal/workflows/instantly/webhook_reply_received_workflow.py
+++ b/temporal/workflows/instantly/webhook_reply_received_workflow.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+from pydantic import BaseModel, Field
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
+
+from temporal.shared import WAITING_FOR_RESUME_KEY_STR
+
+ENV_TYPE = os.getenv("ENV_TYPE", "development")
+
+with workflow.unsafe.imports_passed_through():
+    from temporal.activities.instantly.webhook_reply_received import (
+        AddEmailActivityToLeadArgs,
+        AddEmailActivityToLeadResult,
+        PauseSequenceSubscriptionsArgs,
+        PauseSequenceSubscriptionsResult,
+        SendNotificationEmailArgs,
+        WebhookReplyReceivedPayloadValidated,
+        add_email_activity_to_lead,
+        pause_sequence_subscriptions,
+        send_notification_email,
+    )
+
+
+class WebhookReplyReceivedPayload(BaseModel):
+    json_payload: dict = Field(..., description="JSON payload of the request")
+
+
+@workflow.defn
+class WebhookReplyReceivedWorkflow:
+    def __init__(self) -> None:
+        self._data_issue_fixed: bool = True
+        self._activity_retry_policy = RetryPolicy(
+            initial_interval=timedelta(seconds=5),
+            maximum_attempts=3,
+        )
+
+    @workflow.signal
+    def data_issue_fixed(self) -> None:
+        self._data_issue_fixed = True
+
+    @workflow.run
+    async def run(self, input: WebhookReplyReceivedPayload) -> None:
+        input_validated = self._validate_input(input)
+
+        add_email_result = await self._add_email_activity_to_lead(input_validated)
+
+        pause_result = await self._pause_sequence_subscriptions(
+            add_email_result.lead_id,
+            input_validated.lead_email,
+        )
+
+        await self._send_notification_email(
+            add_email_result,
+            pause_result,
+            input_validated,
+        )
+
+    async def _add_email_activity_to_lead(
+        self,
+        input_validated: WebhookReplyReceivedPayloadValidated,
+    ) -> AddEmailActivityToLeadResult:
+        while True:
+            try:
+                return await workflow.execute_activity(
+                    add_email_activity_to_lead,
+                    AddEmailActivityToLeadArgs(payload=input_validated),
+                    start_to_close_timeout=timedelta(seconds=10),
+                    retry_policy=self._activity_retry_policy,
+                )
+            except Exception:
+                await self._wait_for_signal_data_issue_fixed()
+
+    async def _pause_sequence_subscriptions(
+        self,
+        lead_id: str,
+        lead_email: str,
+    ) -> PauseSequenceSubscriptionsResult:
+        while True:
+            try:
+                return await workflow.execute_activity(
+                    pause_sequence_subscriptions,
+                    PauseSequenceSubscriptionsArgs(
+                        lead_id=lead_id, lead_email=lead_email
+                    ),
+                    start_to_close_timeout=timedelta(seconds=10),
+                    retry_policy=self._activity_retry_policy,
+                )
+            except Exception:
+                await self._wait_for_signal_data_issue_fixed()
+
+    async def _send_notification_email(
+        self,
+        add_email_result: AddEmailActivityToLeadResult,
+        pause_result: PauseSequenceSubscriptionsResult,
+        input_validated: WebhookReplyReceivedPayloadValidated,
+    ) -> None:
+        while True:
+            try:
+                await workflow.execute_activity(
+                    send_notification_email,
+                    SendNotificationEmailArgs(
+                        lead_id=add_email_result.lead_id,
+                        lead_email=add_email_result.lead_email,
+                        lead_name=add_email_result.lead_name,
+                        campaign_name=input_validated.campaign_name,
+                        reply_subject=input_validated.reply_subject,
+                        reply_text=input_validated.reply_text,
+                        reply_html=input_validated.reply_html,
+                        env_type=ENV_TYPE,
+                        paused_subscriptions=pause_result.paused_subscriptions,
+                        lead_details=add_email_result.lead_details,
+                        email_activity_id=add_email_result.email_activity_id,
+                    ),
+                    start_to_close_timeout=timedelta(seconds=10),
+                    retry_policy=self._activity_retry_policy,
+                )
+                return
+            except Exception:
+                await self._wait_for_signal_data_issue_fixed()
+
+    async def _wait_for_signal_data_issue_fixed(self) -> None:
+        self._data_issue_fixed = False
+        workflow.upsert_search_attributes({WAITING_FOR_RESUME_KEY_STR: [True]})
+        await workflow.wait_condition(lambda: self._data_issue_fixed)
+        workflow.upsert_search_attributes({WAITING_FOR_RESUME_KEY_STR: [False]})
+
+    @staticmethod
+    def _validate_input(
+        input: WebhookReplyReceivedPayload,
+    ) -> WebhookReplyReceivedPayloadValidated:
+        payload = input.json_payload
+        try:
+            validated = WebhookReplyReceivedPayloadValidated(
+                event_type=payload["event_type"],
+                lead_email=payload["lead_email"],
+                campaign_name=payload["campaign_name"],
+                reply_subject=payload["reply_subject"],
+                reply_text=payload.get("reply_text"),
+                reply_html=payload.get("reply_html"),
+                timestamp=payload["timestamp"],
+                email_account=payload["email_account"],
+            )
+        except KeyError as exc:
+            raise ApplicationError(
+                f"Missing required field in reply received payload: {exc}"
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise ApplicationError(
+                f"Invalid payload for reply received webhook: {exc}"
+            ) from exc
+
+        if validated.event_type != "reply_received":
+            raise ApplicationError(
+                f"Expected reply_received event, got {validated.event_type}"
+            )
+
+        if not (validated.reply_text or validated.reply_html):
+            raise ApplicationError(
+                "Either reply_text or reply_html must be provided"
+            )
+
+        return validated
+
+
+__all__ = [
+    "WebhookReplyReceivedPayload",
+    "WebhookReplyReceivedWorkflow",
+]

--- a/tests/unit/instantly/test_consultant_notification.py
+++ b/tests/unit/instantly/test_consultant_notification.py
@@ -12,7 +12,7 @@ import sys
 # Add the project root to the path so we can import blueprints
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
 
-from blueprints.instantly import determine_notification_recipients
+from utils.instantly_reply_received import determine_notification_recipients
 
 
 class TestConsultantNotification:

--- a/tests/unit/instantly/test_reply_received_temporal.py
+++ b/tests/unit/instantly/test_reply_received_temporal.py
@@ -1,0 +1,264 @@
+from typing import Any, Dict
+
+import pytest
+from flask import Flask
+
+from blueprints import instantly
+from temporal.workflows.instantly.webhook_reply_received_workflow import (
+    WebhookReplyReceivedPayload,
+    WebhookReplyReceivedWorkflow,
+)
+from temporalio.exceptions import ApplicationError
+from temporal.activities.instantly import webhook_reply_received as activities
+
+
+@pytest.fixture()
+def flask_app():
+    app = Flask(__name__)
+    app.register_blueprint(instantly.instantly_bp, url_prefix="/instantly")
+    return app
+
+
+def _make_request(client, json_payload: Dict[str, Any]):
+    return client.post("/instantly/reply_received", json=json_payload)
+
+
+def test_reply_received_route_uses_temporal_when_flag_enabled(monkeypatch, flask_app):
+    monkeypatch.setattr(instantly, "use_temporal_for_reply_received", True, raising=False)
+    monkeypatch.setattr(
+        instantly,
+        "handle_instantly_reply_received_temporal",
+        lambda: ("temporal", 202),
+    )
+    monkeypatch.setattr(
+        instantly,
+        "handle_instantly_reply_received_sync",
+        lambda: ("sync", 200),
+    )
+
+    with flask_app.test_client() as client:
+        response = _make_request(client, {})
+
+    assert response.status_code == 202
+    assert response.get_data(as_text=True) == "temporal"
+
+
+def test_reply_received_route_uses_sync_when_flag_disabled(monkeypatch, flask_app):
+    monkeypatch.setattr(instantly, "use_temporal_for_reply_received", False, raising=False)
+    monkeypatch.setattr(
+        instantly,
+        "handle_instantly_reply_received_temporal",
+        lambda: ("temporal", 202),
+    )
+    monkeypatch.setattr(
+        instantly,
+        "handle_instantly_reply_received_sync",
+        lambda: ("sync", 200),
+    )
+
+    with flask_app.test_client() as client:
+        response = _make_request(client, {})
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "sync"
+
+
+def test_handle_reply_received_temporal_enqueues_workflow(monkeypatch, flask_app):
+    start_args: Dict[str, Any] = {}
+
+    class FakeClient:
+        def start_workflow(self, *args, **kwargs):
+            start_args["args"] = args
+            start_args["kwargs"] = kwargs
+            return "fake-coro"
+
+    def fake_run(coro):
+        start_args["ran"] = coro
+        return None
+
+    monkeypatch.setattr(instantly, "use_temporal_for_reply_received", True, raising=False)
+    monkeypatch.setattr(instantly.temporal, "ensure_started", lambda: None)
+    monkeypatch.setattr(instantly.temporal, "client", FakeClient(), raising=False)
+    monkeypatch.setattr(instantly.temporal, "run", fake_run, raising=False)
+
+    payload = {
+        "event_type": "reply_received",
+        "lead_email": "lead@example.com",
+        "campaign_name": "Test Campaign",
+        "reply_subject": "Re: Hi",
+        "reply_text": "Hello",
+        "timestamp": "2023-09-01T12:00:00Z",
+        "email_account": "consultant@example.com",
+    }
+
+    with flask_app.test_client() as client:
+        response = _make_request(client, payload)
+
+    assert response.status_code == 202
+    body = response.get_json()
+    assert body["status"] == "accepted"
+    assert start_args["args"][0] == WebhookReplyReceivedWorkflow.run
+    workflow_input = start_args["args"][1]
+    assert isinstance(workflow_input, WebhookReplyReceivedPayload)
+    assert workflow_input.json_payload == payload
+
+
+def test_handle_reply_received_temporal_invalid_payload_returns_400(monkeypatch, flask_app):
+    monkeypatch.setattr(instantly, "use_temporal_for_reply_received", True, raising=False)
+
+    with flask_app.test_client() as client:
+        response = client.post("/instantly/reply_received", data="not-json")
+
+    assert response.status_code == 400
+
+
+def test_workflow_validation_requires_reply_body():
+    payload = WebhookReplyReceivedPayload(
+        json_payload={
+            "event_type": "reply_received",
+            "lead_email": "lead@example.com",
+            "campaign_name": "Test",
+            "reply_subject": "Subject",
+            "reply_text": None,
+            "reply_html": None,
+            "timestamp": "2023-09-01T12:00:00Z",
+            "email_account": "consultant@example.com",
+        }
+    )
+
+    with pytest.raises(ApplicationError):
+        WebhookReplyReceivedWorkflow._validate_input(payload)
+
+
+def test_send_notification_email_uses_custom_recipients(monkeypatch):
+    args = activities.SendNotificationEmailArgs(
+        lead_id="lead123",
+        lead_email="lead@example.com",
+        lead_name="Lead",
+        campaign_name="Campaign",
+        reply_subject="Subject",
+        reply_text="Body",
+        reply_html=None,
+        env_type="production",
+        paused_subscriptions=[],
+        lead_details={"id": "lead123"},
+        email_activity_id="email456",
+    )
+
+    monkeypatch.setattr(
+        activities,
+        "determine_notification_recipients",
+        lambda *_: ("consultant@example.com", None),
+    )
+
+    recorded_kwargs: Dict[str, Any] = {}
+
+    def fake_send_email(**kwargs):
+        recorded_kwargs.update(kwargs)
+        return {"status": "sent", "message_id": "msg-123"}
+
+    monkeypatch.setattr(activities, "send_email", fake_send_email)
+
+    result = activities.send_notification_email(args)
+
+    assert result.notification_status == "sent"
+    assert result.custom_recipients_used is True
+    assert recorded_kwargs["recipients"] == "consultant@example.com"
+
+
+def test_send_notification_email_raises_for_consultant_errors(monkeypatch):
+    args = activities.SendNotificationEmailArgs(
+        lead_id="lead123",
+        lead_email="lead@example.com",
+        lead_name="Lead",
+        campaign_name="Campaign",
+        reply_subject="Subject",
+        reply_text="Body",
+        reply_html=None,
+        env_type="production",
+        paused_subscriptions=[],
+        lead_details={"id": "lead123"},
+        email_activity_id="email456",
+    )
+
+    monkeypatch.setattr(
+        activities,
+        "determine_notification_recipients",
+        lambda *_: (None, "bad consultant"),
+    )
+
+    with pytest.raises(ValueError):
+        activities.send_notification_email(args)
+
+
+def test_add_email_activity_to_lead_returns_metadata(monkeypatch):
+    payload = activities.WebhookReplyReceivedPayloadValidated(
+        event_type="reply_received",
+        lead_email="lead@example.com",
+        campaign_name="Campaign",
+        reply_subject="Subject",
+        reply_text="Body",
+        reply_html=None,
+        timestamp="2023-09-01T12:00:00Z",
+        email_account="consultant@example.com",
+    )
+
+    monkeypatch.setattr(activities, "create_email_search_query", lambda _: "query")
+    monkeypatch.setattr(
+        activities,
+        "search_close_leads",
+        lambda _: [{"id": "lead123"}],
+    )
+    monkeypatch.setattr(
+        activities,
+        "get_lead_by_id",
+        lambda _: {
+            "id": "lead123",
+            "name": "Lead",
+            "contacts": [
+                {
+                    "id": "contact123",
+                    "emails": [{"email": "lead@example.com"}],
+                }
+            ],
+        },
+    )
+
+    class FakeResponse:
+        def json(self):
+            return {"id": "email456"}
+
+    monkeypatch.setattr(
+        activities,
+        "make_close_request",
+        lambda *_, **__: FakeResponse(),
+    )
+
+    result = activities.add_email_activity_to_lead(
+        activities.AddEmailActivityToLeadArgs(payload=payload)
+    )
+
+    assert result.lead_id == "lead123"
+    assert result.email_activity_id == "email456"
+    assert result.lead_details["id"] == "lead123"
+
+
+def test_add_email_activity_to_lead_raises_when_no_leads(monkeypatch):
+    payload = activities.WebhookReplyReceivedPayloadValidated(
+        event_type="reply_received",
+        lead_email="missing@example.com",
+        campaign_name="Campaign",
+        reply_subject="Subject",
+        reply_text="Body",
+        reply_html=None,
+        timestamp="2023-09-01T12:00:00Z",
+        email_account="consultant@example.com",
+    )
+
+    monkeypatch.setattr(activities, "create_email_search_query", lambda _: "query")
+    monkeypatch.setattr(activities, "search_close_leads", lambda _: [])
+
+    with pytest.raises(ValueError):
+        activities.add_email_activity_to_lead(
+            activities.AddEmailActivityToLeadArgs(payload=payload)
+        )

--- a/utils/instantly_reply_received.py
+++ b/utils/instantly_reply_received.py
@@ -1,0 +1,78 @@
+"""Helpers shared by Instantly reply-received webhook handlers."""
+
+import structlog
+
+logger = structlog.get_logger("instantly.reply_received")
+
+CONSULTANT_FIELD_KEY = "custom.lcf_TRIulkQaxJArdGl2k89qY6NKR0ZTYkzjRdeILo1h5fi"
+
+
+def determine_notification_recipients(lead_details, env_type):
+    """Return consultant-specific recipients (if any) for reply notifications."""
+    consultant = lead_details.get(CONSULTANT_FIELD_KEY)
+    lead_id = lead_details.get("id", "unknown")
+
+    if consultant is None:
+        logger.warning(
+            "consultant_field_missing",
+            lead_id=lead_id,
+            message=f"Consultant field missing for lead {lead_id}. Using default recipients.",
+        )
+        return None, None
+
+    if consultant == "":
+        logger.warning(
+            "consultant_field_empty",
+            lead_id=lead_id,
+            message=f"Consultant field empty for lead {lead_id}. Using default recipients.",
+        )
+        return None, None
+
+    if consultant == "Barbara Pigg":
+        logger.info(
+            "consultant_determined",
+            lead_id=lead_id,
+            consultant="Barbara Pigg",
+            recipients="default",
+        )
+        return None, None
+
+    if consultant == "April Lowrie":
+        if env_type == "development":
+            recipients = "lance@whiteboardgeeks.com"
+            logger.info(
+                "consultant_determined",
+                lead_id=lead_id,
+                consultant="April Lowrie",
+                environment="development",
+                recipients=recipients,
+            )
+            return recipients, None
+
+        recipients_list = [
+            "april.lowrie@whiteboardgeeks.com",
+            "lauren.poche@whiteboardgeeks.com",
+        ]
+        recipients = ",".join(recipients_list)
+        logger.info(
+            "consultant_determined",
+            lead_id=lead_id,
+            consultant="April Lowrie",
+            environment="production",
+            recipients=recipients,
+        )
+        return recipients, None
+
+    logger.warning(
+        "consultant_unknown",
+        lead_id=lead_id,
+        consultant=consultant,
+        message=f"Unknown consultant '{consultant}' for lead {lead_id}. Using default recipients.",
+    )
+    return None, None
+
+
+__all__ = [
+    "CONSULTANT_FIELD_KEY",
+    "determine_notification_recipients",
+]


### PR DESCRIPTION
changes in this PR:

* introduce the USE_TEMPORAL_FOR_REPLY_RECEIVED feature flag and split /instantly/reply_received into sync vs Temporal code paths, moving consultant-recipient logic into a shared helper
* add the new Temporal workflow and activities for reply-received processing and register them with the worker
* expand unit/integration coverage for both execution modes and update the CI pipeline to execute Instantly integration tests with the flag disabled and enabled