### PR TITLE
Exclude 'Lance' campaigns from Instantly webhook automation

### DIFF
--- a/blueprints/instantly.py
+++ b/blueprints/instantly.py
@@ -426,13 +426,30 @@ def list_instantly_campaigns():
         return jsonify(campaigns), 200 if campaigns.get("status") != "error" else 500
 
 
+def _campaign_name_excluded(campaign_name):
+    """Campaigns with 'lance' in the name are personal/raise campaigns that must
+    bypass mailer automation (Close task completion, reply routing, etc.)."""
+    return bool(campaign_name) and "lance" in campaign_name.lower()
+
+
 @instantly_bp.route("/email_sent", methods=["POST"])
 def handle_instantly_email_sent():
     """Handle webhooks from Instantly when an email is sent."""
     g_run_id = getattr(g, "request_id", str(uuid.uuid4()))
 
+    json_payload = request.get_json()
+    campaign_name = (json_payload or {}).get("campaign_name")
+    if _campaign_name_excluded(campaign_name):
+        logger.info(
+            "instantly_webhook_excluded",
+            route="email_sent",
+            campaign_name=campaign_name,
+            run_id=g_run_id,
+        )
+        return jsonify({"status": "ignored", "message": "Campaign excluded from automation"}), 200
+
     input = WebhookEmailSentPayload(
-        json_payload=request.get_json(),
+        json_payload=json_payload,
     )
 
     _ = temporal.run(temporal.client.start_workflow(
@@ -463,11 +480,25 @@ def handle_instantly_reply_received_temporal():
 
     g_run_id = getattr(g, "request_id", str(uuid.uuid4()))
 
+    campaign_name = json_payload.get("campaign_name")
+    if _campaign_name_excluded(campaign_name):
+        logger.info(
+            "instantly_webhook_excluded",
+            route="reply_received",
+            campaign_name=campaign_name,
+            run_id=g_run_id,
+        )
+        response_data = {
+            "status": "ignored",
+            "message": "Campaign excluded from automation",
+        }
+        return log_webhook_response(200, response_data, {"campaign_name": campaign_name})
+
     logger.info(
         "reply_received_temporal_enqueue",
         run_id=g_run_id,
         event_type=json_payload.get("event_type"),
-        campaign_name=json_payload.get("campaign_name"),
+        campaign_name=campaign_name,
         lead_email=json_payload.get("lead_email"),
     )
 

--- a/tests/unit/instantly/test_campaign_exclusion.py
+++ b/tests/unit/instantly/test_campaign_exclusion.py
@@ -1,0 +1,67 @@
+"""Tests for excluding 'Lance' campaigns from Instantly webhook automation.
+
+Campaigns with 'lance' in the name (e.g. capital-raise outreach) must bypass the
+mailer automation entirely — no Close task completion, no reply routing — so they
+never enqueue a Temporal workflow.
+"""
+
+from typing import Any, Dict
+
+import pytest
+from flask import Flask
+
+from blueprints import instantly
+
+
+@pytest.fixture()
+def flask_app():
+    app = Flask(__name__)
+    app.register_blueprint(instantly.instantly_bp, url_prefix="/instantly")
+    return app
+
+
+def _fail_if_temporal_used(monkeypatch):
+    """Make any Temporal enqueue blow up, so excluded campaigns are proven to skip it."""
+    def boom(*args, **kwargs):
+        raise AssertionError("Temporal must not be invoked for excluded campaigns")
+
+    monkeypatch.setattr(instantly.temporal, "ensure_started", lambda: None, raising=False)
+    monkeypatch.setattr(instantly.temporal, "run", boom, raising=False)
+
+
+@pytest.mark.parametrize("name", ["Lance Conroe 2026-06-01", "lance_test", "MY LANCE RAISE"])
+def test_campaign_name_excluded_true(name):
+    assert instantly._campaign_name_excluded(name) is True
+
+
+@pytest.mark.parametrize("name", ["BP_BC_BlindInviteEmail1", "APRIL_BC_NoShowEmail1", "", None])
+def test_campaign_name_excluded_false(name):
+    assert instantly._campaign_name_excluded(name) is False
+
+
+def test_reply_received_excluded_campaign_skips_temporal(monkeypatch, flask_app):
+    _fail_if_temporal_used(monkeypatch)
+    payload: Dict[str, Any] = {
+        "event_type": "reply_received",
+        "lead_email": "lead@example.com",
+        "campaign_name": "Lance Conroe 2026-06-01",
+        "reply_subject": "Re: Hi",
+        "reply_text": "Hello",
+        "timestamp": "2023-09-01T12:00:00Z",
+        "email_account": "consultant@example.com",
+    }
+    with flask_app.test_client() as client:
+        response = client.post("/instantly/reply_received", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "ignored"
+
+
+def test_email_sent_excluded_campaign_skips_temporal(monkeypatch, flask_app):
+    _fail_if_temporal_used(monkeypatch)
+    payload = {"campaign_name": "Lance Conroe 2026-06-01", "lead_email": "lead@example.com"}
+    with flask_app.test_client() as client:
+        response = client.post("/instantly/email_sent", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "ignored"


### PR DESCRIPTION
## What
Campaigns whose name contains **"lance"** (case-insensitive) now bypass the mailer automation entirely.

- New helper `_campaign_name_excluded()` in `blueprints/instantly.py`.
- Guards added to both webhook routes: `/instantly/email_sent` and `/instantly/reply_received`.
- Excluded campaigns return `200 {"status":"ignored"}` and **never enqueue a Temporal workflow** (no Close task completion, no reply routing).

## Why
Capital-raise outreach (e.g. `Lance Conroe 2026-06-01`) runs through Instantly on the shared workspace, but investor replies/sends must not flow into the WBG mailer pipeline. Webhooks are workspace-global in Instantly with no per-campaign filter, so the exclusion is enforced on the consumer side.

## Tests
- `tests/unit/instantly/test_campaign_exclusion.py` — helper truth table + both routes proven to skip Temporal.
- Full unit suite green: **124 passed**.

## Note
Matches on substring "lance" per request — covers `Lance *` campaigns automatically. Merging to `main` does **not** deploy; the prod Heroku app (`heroku-prod`) still needs a deploy for this to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)