### PR TITLE
Fix search_close_leads masking transient Close failures as empty results

### DIFF
--- a/close_utils.py
+++ b/close_utils.py
@@ -296,7 +296,17 @@ def search_close_leads(query):
         query (dict): The Close query to execute.
 
     Returns:
-        list: A list of leads matching the query, or empty list if none found or error occurs.
+        list: The leads matching the query. An empty list means the search
+            succeeded but matched nothing.
+
+    Raises:
+        Exception: if the Close API request itself fails (rate limiting, timeout,
+            5xx, or a malformed response). Callers MUST NOT treat a failed
+            request as "no leads found". Doing so previously caused Temporal
+            activities to permanently park on transient Close errors (the real
+            error was masked and surfaced as a misleading "No lead found"), and
+            caused the EasyPost delivery flow to silently no-op real deliveries.
+            Letting the exception propagate lets the Temporal activity retry.
     """
     try:
         data_to_return = []
@@ -338,16 +348,18 @@ def search_close_leads(query):
                 break
 
         if not data_to_return:
-            logger.warning("No leads found in Close API search")
-            return []  # Return empty list instead of None
+            logger.info("Close API search succeeded with no matching leads")
 
         return data_to_return
 
     except Exception as e:
+        # Log for diagnostics, then RE-RAISE. A failed request is NOT the same as
+        # "no leads found": returning [] here previously masked transient Close
+        # failures and parked Temporal workflows forever. See the docstring.
         logger.error(f"Failed to search Close leads: {e}")
         logger.error(f"Query used: {query}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        return []  # Return empty list instead of None
+        raise
 
 
 def get_lead_by_id(lead_id) -> dict | None:

--- a/tests/unit/close_rate_limiter/test_close_utils_integration.py
+++ b/tests/unit/close_rate_limiter/test_close_utils_integration.py
@@ -285,6 +285,33 @@ class TestCloseUtilsIntegration:
         # Verify result
         assert result == [{"id": "lead_123"}]
 
+    @patch("close_utils.make_close_request")
+    def test_search_close_leads_empty_result_returns_empty_list(self, mock_make_request):
+        """A successful search that matches nothing returns []."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": [], "cursor": None}
+        mock_make_request.return_value = mock_response
+
+        result = search_close_leads({"query": {"queries": []}})
+
+        assert result == []
+
+    @patch("close_utils.make_close_request")
+    def test_search_close_leads_propagates_request_failure(self, mock_make_request):
+        """A failed Close request must RAISE, not be masked as "no leads found".
+
+        Regression guard: returning [] on transient failures (rate limiting,
+        timeouts, 5xx) made callers conclude the lead/task was absent, which
+        permanently parked Temporal workflows and silently no-op'd EasyPost
+        deliveries. The exception must propagate so the activity retries.
+        """
+        mock_make_request.side_effect = requests.exceptions.RequestException(
+            "Rate limit exceeded after retries"
+        )
+
+        with pytest.raises(requests.exceptions.RequestException):
+            search_close_leads({"query": {"queries": []}})
+
     @patch("close_utils.get_close_rate_limiter")
     def test_rate_limiter_header_parsing_integration(self, mock_get_limiter):
         """Test that response headers are parsed and cached."""


### PR DESCRIPTION
## Problem
`search_close_leads` caught every exception and returned `[]`, so transient Close API failures (rate-limit token starvation from the `@close_rate_limit` decorator, timeouts, 5xx) during Instantly send waves were indistinguishable from a genuine empty result. Callers then concluded "No lead found" / "Could not find task" and parked `WebhookEmailSentWorkflow` runs **forever** on the manual `data_issue_fixed` signal. The EasyPost delivery flow silently no-op'd real deliveries for the same reason (its `try/except` around `search_close_leads` was effectively dead code).

This is what caused the 6/1–6/3 backlog of 339 stuck `WebhookEmailSentWorkflow` runs.

## Fix
`search_close_leads` now re-raises on request failure (keeping the diagnostic logging) and returns `[]` only when the search genuinely matches nothing — so the Temporal activity retries on transient errors instead of misreporting absence, and EasyPost only no-ops on a true empty result.

## Tests
Added regression tests (empty → `[]`; request failure → raises). Full unit suite green: **126 passed**.

## Not included (deliberate)
Retry-budget tuning (`TEMPORAL_WORKFLOW_ACTIVITY_MAX_ATTEMPTS = 3`) is shared with `is_last_attempt` alerting and ripples into tests — left for a measured follow-up. A long wave can still park workflows, but now with accurate errors and cleanly resumable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)