### PR TITLE
Self-host Temporal with mTLS and Cloud drain

### DIFF
--- a/.github/workflows/cutover-temporal.yml
+++ b/.github/workflows/cutover-temporal.yml
@@ -1,0 +1,54 @@
+name: Cut over Heroku to self-hosted Temporal
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Heroku app to update
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - production
+          - staging
+
+permissions:
+  contents: read
+
+jobs:
+  production:
+    if: inputs.target == 'both' || inputs.target == 'production'
+    runs-on: ubuntu-latest
+    env:
+      APP_NAME: mailer-automation
+      TEMPORAL_NAMESPACE: mailerautomation-prod
+      TEMPORAL_LEGACY_ADDRESS: ${{ secrets.TEMPORAL_LEGACY_ADDRESS_PROD }}
+      TEMPORAL_LEGACY_NAMESPACE: ${{ secrets.TEMPORAL_LEGACY_NAMESPACE_PROD }}
+      TEMPORAL_LEGACY_API_KEY: ${{ secrets.TEMPORAL_LEGACY_API_KEY_PROD }}
+      TEMPORAL_TLS_CA_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CA_BASE64 }}
+      TEMPORAL_TLS_CERT_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CLIENT_CERT_BASE64 }}
+      TEMPORAL_TLS_KEY_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CLIENT_KEY_BASE64 }}
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update production config vars
+        run: .github/workflows/scripts/cutover-temporal.sh
+
+  staging:
+    if: inputs.target == 'both' || inputs.target == 'staging'
+    runs-on: ubuntu-latest
+    env:
+      APP_NAME: mailer-automation-staging
+      TEMPORAL_NAMESPACE: mailerautomation-staging
+      TEMPORAL_LEGACY_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS_STAGING }}
+      TEMPORAL_LEGACY_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE_STAGING }}
+      TEMPORAL_LEGACY_API_KEY: ${{ secrets.TEMPORAL_API_KEY_STAGING }}
+      TEMPORAL_TLS_CA_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CA_BASE64 }}
+      TEMPORAL_TLS_CERT_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CLIENT_CERT_BASE64 }}
+      TEMPORAL_TLS_KEY_BASE64: ${{ secrets.TEMPORAL_SELF_HOSTED_CLIENT_KEY_BASE64 }}
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update staging config vars
+        run: .github/workflows/scripts/cutover-temporal.sh

--- a/.github/workflows/scripts/cutover-temporal.sh
+++ b/.github/workflows/scripts/cutover-temporal.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${APP_NAME:?APP_NAME is required}"
+: "${HEROKU_API_KEY:?HEROKU_API_KEY is required}"
+: "${TEMPORAL_NAMESPACE:?TEMPORAL_NAMESPACE is required}"
+: "${TEMPORAL_LEGACY_ADDRESS:?TEMPORAL_LEGACY_ADDRESS is required}"
+: "${TEMPORAL_LEGACY_NAMESPACE:?TEMPORAL_LEGACY_NAMESPACE is required}"
+: "${TEMPORAL_LEGACY_API_KEY:?TEMPORAL_LEGACY_API_KEY is required}"
+: "${TEMPORAL_TLS_CA_BASE64:?TEMPORAL_TLS_CA_BASE64 is required}"
+: "${TEMPORAL_TLS_CERT_BASE64:?TEMPORAL_TLS_CERT_BASE64 is required}"
+: "${TEMPORAL_TLS_KEY_BASE64:?TEMPORAL_TLS_KEY_BASE64 is required}"
+
+python3 - <<'PY' >/tmp/temporal-config.json
+import json
+import os
+
+namespace = os.environ["TEMPORAL_NAMESPACE"]
+print(json.dumps({
+    "TEMPORAL_ADDRESS": "app.whiteboardgeeks.com:7233",
+    "TEMPORAL_NAMESPACE": namespace,
+    "TEMPORAL_API_KEY": None,
+    "TEMPORAL_TLS": None,
+    "TEMPORAL_TLS_CA": None,
+    "TEMPORAL_TLS_CERT": None,
+    "TEMPORAL_TLS_KEY": None,
+    "TEMPORAL_TLS_CA_BASE64": os.environ["TEMPORAL_TLS_CA_BASE64"],
+    "TEMPORAL_TLS_CERT_BASE64": os.environ["TEMPORAL_TLS_CERT_BASE64"],
+    "TEMPORAL_TLS_KEY_BASE64": os.environ["TEMPORAL_TLS_KEY_BASE64"],
+    "TEMPORAL_TLS_SERVER_NAME": "app.whiteboardgeeks.com",
+    "TEMPORAL_WORKFLOW_UI_BASE_URL": (
+        "https://app.whiteboardgeeks.com/temporal/namespaces/"
+        f"{namespace}/workflows"
+    ),
+    "TEMPORAL_LEGACY_ADDRESS": os.environ["TEMPORAL_LEGACY_ADDRESS"],
+    "TEMPORAL_LEGACY_NAMESPACE": os.environ["TEMPORAL_LEGACY_NAMESPACE"],
+    "TEMPORAL_LEGACY_API_KEY": os.environ["TEMPORAL_LEGACY_API_KEY"],
+}))
+PY
+
+curl --silent --show-error --fail \
+  --request PATCH \
+  "https://api.heroku.com/apps/${APP_NAME}/config-vars" \
+  --header "Accept: application/vnd.heroku+json; version=3" \
+  --header "Authorization: Bearer ${HEROKU_API_KEY}" \
+  --header "Content-Type: application/json" \
+  --data-binary @/tmp/temporal-config.json \
+  --output /dev/null
+
+rm -f /tmp/temporal-config.json
+echo "Updated ${APP_NAME}; Heroku is restarting its dynos."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,17 @@
 
 - **Heroku app (prod):** `mailer-automation` — `web` ×2 + `worker_temporal` ×1, addons `papertrail` + `rediscloud` (whiteboard-geeks team)
 - **Heroku app (staging):** `mailer-automation-staging`
-- **Temporal Cloud:** namespace `mailerautomation-prod.y3flc`, gRPC `mailerautomation-prod.y3flc.tmprl.cloud:7233`, UI https://cloud.temporal.io/namespaces/mailerautomation-prod.y3flc/workflows
-- The Flask web dynos enqueue Temporal workflows; the `worker_temporal` dyno runs the activities.
+- **Temporal (self-hosted):** Whiteboard Geeks Hetzner `wbg-apps`, namespace `mailerautomation-prod`, mTLS gRPC `app.whiteboardgeeks.com:7233`, SSO UI https://app.whiteboardgeeks.com/temporal/namespaces/mailerautomation-prod/workflows
+- **Legacy drain:** old Temporal Cloud namespace `mailerautomation-prod.y3flc` remains only for pre-cutover open workflows. The worker polls both clusters until the Cloud open-workflow count reaches zero.
+- The Flask web dynos enqueue new workflows on self-hosted Temporal; the `worker_temporal` dyno runs activities for both the primary and temporary legacy clusters.
 
 ## Logs & where to look first
 
 | Symptom | First place to look |
 |---|---|
 | Webhook not triggering anything downstream | `heroku logs -a mailer-automation -n 1500 \| grep <route>` — confirms the request hit Flask and was/wasn't enqueued |
-| Workflow ran but produced wrong output | Temporal Cloud UI → search by workflow id, view event history. Or `temporal --env prod workflow show -w <id>` |
-| "Did the worker actually pick this up?" | Temporal UI status. `RUNNING` for >1 min usually means an activity is failing or waiting on `_data_issue_fixed` signal |
+| Workflow ran but produced wrong output | Self-hosted Temporal UI → search by workflow id and view event history. For pre-cutover workflows, use `temporal --env prod workflow show -w <id>` against legacy Cloud. |
+| "Did the worker actually pick this up?" | Temporal UI status. `RUNNING` for >1 min usually means an activity is failing or waiting on `_data_issue_fixed` signal. Check both clusters during the drain. |
 | Older than ~12h | Heroku CLI tail is short — use **Papertrail** (addon `PAPERTRAIL`, `heroku addons:open papertrail -a mailer-automation`) |
 | Redis-related | `rediscloud:100` addon |
 
@@ -21,7 +22,7 @@ Papertrail keeps logs much longer than `heroku logs` (which is rolling, only 150
 
 ## Temporal CLI
 
-A `prod` env is configured at `~/.config/temporalio/temporal.yaml`. Useful one-liners:
+The `prod` env at `~/.config/temporalio/temporal.yaml` intentionally remains pointed at legacy Cloud during the drain. Self-hosted server operations and backups are documented in `infra/temporal/README.md`. Useful legacy one-liners:
 
 ```sh
 temporal --env prod workflow list --limit 20 --query 'WorkflowType="WebhookDeliveryStatusWorkflow"'

--- a/infra/temporal/.env.example
+++ b/infra/temporal/.env.example
@@ -1,0 +1,6 @@
+TEMPORAL_VERSION=1.31.0
+TEMPORAL_UI_VERSION=2.49.1
+POSTGRES_USER=temporal
+POSTGRES_PASSWORD=replace-with-a-long-random-password
+PROD_NAMESPACE=mailerautomation-prod
+STAGING_NAMESPACE=mailerautomation-staging

--- a/infra/temporal/.gitignore
+++ b/infra/temporal/.gitignore
@@ -1,0 +1,3 @@
+.env
+pki/
+backups/

--- a/infra/temporal/README.md
+++ b/infra/temporal/README.md
@@ -1,0 +1,77 @@
+# Self-hosted Temporal for MailerAutomation
+
+This stack runs the production and staging Temporal namespaces on the Whiteboard
+Geeks Hetzner application server.
+
+## Topology
+
+- Temporal Server `1.31.0`, pinned through `.env`
+- PostgreSQL 16 with separate `temporal` and `temporal_visibility` databases
+- PostgreSQL advanced Visibility (no Elasticsearch at this workload)
+- HAProxy on public TCP `7233`, requiring a client certificate signed by the
+  private Temporal CA
+- Temporal UI on host loopback `127.0.0.1:8088`, published by Caddy at
+  `https://app.whiteboardgeeks.com/temporal/` behind Google SSO
+- Daily PostgreSQL logical backups in `/var/backups/temporal`, retained 14 days
+
+The Temporal Server itself is not exposed directly. Heroku and GitHub Actions
+connect through the HAProxy mTLS boundary.
+
+## Server installation
+
+The deployed directory is `/opt/temporal`. Secrets are only in:
+
+- `/opt/temporal/.env` (`0600`)
+- `/opt/temporal/pki/ca/` (`0700`; CA private key)
+- `/opt/temporal/pki/proxy/` (`0700`; HAProxy server material)
+- Heroku/GitHub secret stores (client CA, certificate, and key as base64)
+
+Start or update the pinned stack:
+
+```sh
+cd /opt/temporal
+docker compose pull
+docker compose up -d
+```
+
+Check it:
+
+```sh
+docker compose ps
+docker compose logs --since=15m temporal mtls-proxy ui
+```
+
+## Schema upgrades
+
+Do not change `TEMPORAL_VERSION` and blindly recreate the server. Read the
+Temporal upgrade notes, back up first, then run both schema updates with the
+matching `temporalio/admin-tools` image before starting the new server image.
+The initial `schema` service is deliberately one-shot and retained after a
+successful first run.
+
+## Backups
+
+Run and verify a backup manually:
+
+```sh
+systemctl start temporal-backup.service
+systemctl status temporal-backup.service
+ls -lh /var/backups/temporal
+sha256sum -c /var/backups/temporal/sha256-*.txt
+```
+
+These are same-host backups. A Hetzner snapshot or off-host copy is still
+required for host-level disaster recovery.
+
+## Cloud drain
+
+Temporal does not support moving open Workflow histories between clusters.
+During cutover, each Heroku worker polls both clusters:
+
+- `TEMPORAL_*`: self-hosted primary; all new Workflows start here
+- `TEMPORAL_LEGACY_*`: old Temporal Cloud namespace; only existing open
+  Workflows drain here
+
+Do not remove the legacy variables or delete the Cloud namespaces until their
+open Workflow count reaches zero (or the parked Workflows are explicitly
+terminated after review).

--- a/infra/temporal/caddy/temporal.caddy
+++ b/infra/temporal/caddy/temporal.caddy
@@ -1,0 +1,14 @@
+# Temporal UI, mounted at /temporal/ and protected by the shared Google SSO.
+redir /temporal /temporal/ permanent
+
+handle /temporal/* {
+    forward_auth localhost:4180 {
+        uri /code-chat/oauth2/auth
+        copy_headers X-Auth-Request-Email X-Auth-Request-User
+        @denied status 401 403
+        handle_response @denied {
+            redir * /code-chat/oauth2/start?rd={http.request.orig_uri} 302
+        }
+    }
+    reverse_proxy localhost:8088
+}

--- a/infra/temporal/docker-compose.yml
+++ b/infra/temporal/docker-compose.yml
@@ -1,0 +1,162 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "3"
+
+services:
+  postgresql:
+    image: postgres:16-alpine
+    container_name: temporal-postgresql
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+    command:
+      - postgres
+      - -c
+      - shared_buffers=256MB
+      - -c
+      - max_connections=100
+      - -c
+      - log_min_duration_statement=1000
+    volumes:
+      - temporal_postgresql_data:/var/lib/postgresql/data
+    networks:
+      - temporal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    logging: *default-logging
+
+  schema:
+    image: temporalio/admin-tools:${TEMPORAL_VERSION}
+    container_name: temporal-schema
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    environment:
+      DB_PORT: "5432"
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PWD: ${POSTGRES_PASSWORD}
+      POSTGRES_SEEDS: postgresql
+      SQL_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./scripts:/scripts:ro
+    entrypoint: ["/bin/sh"]
+    command: /scripts/setup-postgres.sh
+    networks:
+      - temporal
+    restart: "no"
+    logging: *default-logging
+
+  temporal:
+    image: temporalio/server:${TEMPORAL_VERSION}
+    container_name: temporal-server
+    restart: unless-stopped
+    depends_on:
+      schema:
+        condition: service_completed_successfully
+    environment:
+      DB: postgres12
+      DB_PORT: "5432"
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PWD: ${POSTGRES_PASSWORD}
+      POSTGRES_SEEDS: postgresql
+      BIND_ON_IP: 0.0.0.0
+      NUM_HISTORY_SHARDS: "4"
+      SQL_MAX_CONNS: "10"
+      SQL_MAX_IDLE_CONNS: "10"
+      SQL_VIS_MAX_CONNS: "5"
+      SQL_VIS_MAX_IDLE_CONNS: "5"
+      DYNAMIC_CONFIG_FILE_PATH: config/dynamicconfig/production.yaml
+    volumes:
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:ro
+    networks:
+      - temporal
+    expose:
+      - "7233"
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "7233"]
+      interval: 10s
+      timeout: 3s
+      start_period: 30s
+      retries: 30
+    logging: *default-logging
+
+  namespace-setup:
+    image: temporalio/admin-tools:${TEMPORAL_VERSION}
+    container_name: temporal-namespace-setup
+    depends_on:
+      temporal:
+        condition: service_healthy
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      PROD_NAMESPACE: ${PROD_NAMESPACE}
+      STAGING_NAMESPACE: ${STAGING_NAMESPACE}
+    volumes:
+      - ./scripts:/scripts:ro
+    entrypoint: ["/bin/sh"]
+    command: /scripts/setup-namespaces.sh
+    networks:
+      - temporal
+    restart: "no"
+    logging: *default-logging
+
+  ui:
+    image: temporalio/ui:${TEMPORAL_UI_VERSION}
+    container_name: temporal-ui
+    restart: unless-stopped
+    depends_on:
+      temporal:
+        condition: service_healthy
+      namespace-setup:
+        condition: service_completed_successfully
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_DEFAULT_NAMESPACE: ${PROD_NAMESPACE}
+      TEMPORAL_UI_PUBLIC_PATH: /temporal
+      TEMPORAL_CORS_ORIGINS: https://app.whiteboardgeeks.com
+      TEMPORAL_DISABLE_NEWS_FETCH: "true"
+    networks:
+      - temporal
+    ports:
+      - "127.0.0.1:8088:8080"
+    logging: *default-logging
+
+  mtls-proxy:
+    image: haproxy:3.2-alpine
+    container_name: temporal-mtls-proxy
+    restart: unless-stopped
+    depends_on:
+      temporal:
+        condition: service_healthy
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+      - ./pki/proxy:/usr/local/etc/haproxy/certs:ro
+    networks:
+      - temporal
+    ports:
+      - "7233:7233"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    logging: *default-logging
+
+volumes:
+  temporal_postgresql_data:
+    name: temporal_postgresql_data
+
+networks:
+  temporal:
+    name: temporal
+    driver: bridge

--- a/infra/temporal/dynamicconfig/production.yaml
+++ b/infra/temporal/dynamicconfig/production.yaml
@@ -1,0 +1,5 @@
+# Runtime-updatable settings for this small single-node deployment.
+# Keep the history shard count in docker-compose.yml immutable after first boot.
+limit.maxIDLength:
+  - value: 255
+    constraints: {}

--- a/infra/temporal/haproxy.cfg
+++ b/infra/temporal/haproxy.cfg
@@ -1,0 +1,17 @@
+global
+    log stdout format raw local0
+
+defaults
+    log global
+    mode tcp
+    option tcplog
+    timeout connect 10s
+    timeout client 1h
+    timeout server 1h
+
+frontend temporal_grpc
+    bind :7233 ssl crt /usr/local/etc/haproxy/certs/server.pem ca-file /usr/local/etc/haproxy/certs/ca.pem verify required alpn h2
+    default_backend temporal_server
+
+backend temporal_server
+    server temporal temporal:7233 check inter 5s fall 3 rise 2

--- a/infra/temporal/scripts/backup.sh
+++ b/infra/temporal/scripts/backup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_dir="${TEMPORAL_INSTALL_DIR:-/opt/temporal}"
+backup_dir="${TEMPORAL_BACKUP_DIR:-/var/backups/temporal}"
+retention_days="${TEMPORAL_BACKUP_RETENTION_DAYS:-14}"
+
+cd "$install_dir"
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+umask 077
+mkdir -p "$backup_dir"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+for database in temporal temporal_visibility; do
+  target="$backup_dir/${database}-${timestamp}.dump"
+  temporary="${target}.tmp"
+  docker compose exec -T \
+    -e "PGPASSWORD=${POSTGRES_PASSWORD}" \
+    postgresql \
+    pg_dump -U "$POSTGRES_USER" -Fc "$database" >"$temporary"
+  test -s "$temporary"
+  mv "$temporary" "$target"
+done
+
+globals="$backup_dir/globals-${timestamp}.sql"
+docker compose exec -T \
+  -e "PGPASSWORD=${POSTGRES_PASSWORD}" \
+  postgresql \
+  pg_dumpall -U "$POSTGRES_USER" --globals-only >"$globals"
+test -s "$globals"
+
+sha256sum \
+  "$backup_dir/temporal-${timestamp}.dump" \
+  "$backup_dir/temporal_visibility-${timestamp}.dump" \
+  "$globals" >"$backup_dir/sha256-${timestamp}.txt"
+
+find "$backup_dir" -type f -mtime "+${retention_days}" -delete

--- a/infra/temporal/scripts/setup-namespaces.sh
+++ b/infra/temporal/scripts/setup-namespaces.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+: "${TEMPORAL_ADDRESS:?TEMPORAL_ADDRESS is required}"
+: "${PROD_NAMESPACE:?PROD_NAMESPACE is required}"
+: "${STAGING_NAMESPACE:?STAGING_NAMESPACE is required}"
+
+ensure_namespace() {
+  namespace="$1"
+
+  if ! temporal operator namespace describe --namespace "${namespace}" >/dev/null 2>&1; then
+    temporal operator namespace create \
+      --namespace "${namespace}" \
+      --retention 30d
+  fi
+
+  # Namespace registration is asynchronous. Wait until all frontend calls can
+  # resolve it before creating the namespace-scoped SQL search attribute.
+  attempts=0
+  until temporal operator namespace describe --namespace "${namespace}" >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "Namespace ${namespace} did not become available" >&2
+      return 1
+    fi
+    sleep 2
+  done
+
+  attempts=0
+  while ! attributes="$(
+    temporal operator search-attribute list --namespace "${namespace}" 2>/dev/null
+  )"; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "Visibility for namespace ${namespace} did not become available" >&2
+      return 1
+    fi
+    sleep 2
+  done
+
+  if ! printf '%s\n' "$attributes" | grep -q '^WaitingForResume'; then
+    temporal operator search-attribute create \
+      --namespace "${namespace}" \
+      --name WaitingForResume \
+      --type Bool
+  fi
+}
+
+ensure_namespace "${PROD_NAMESPACE}"
+ensure_namespace "${STAGING_NAMESPACE}"
+
+echo "Temporal namespaces and search attributes are ready."

--- a/infra/temporal/scripts/setup-postgres.sh
+++ b/infra/temporal/scripts/setup-postgres.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -eu
+
+: "${POSTGRES_SEEDS:?POSTGRES_SEEDS is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${SQL_PASSWORD:?SQL_PASSWORD is required}"
+
+export SQL_PASSWORD
+
+until nc -z -w 5 "${POSTGRES_SEEDS}" "${DB_PORT:-5432}"; do
+  echo "Waiting for PostgreSQL..."
+  sleep 2
+done
+
+setup_database() {
+  database="$1"
+  schema_dir="$2"
+
+  if ! temporal-sql-tool \
+      --plugin postgres12 \
+      --ep "${POSTGRES_SEEDS}" \
+      -u "${POSTGRES_USER}" \
+      -p "${DB_PORT:-5432}" \
+      --db "${database}" \
+      describe-version >/dev/null 2>&1; then
+    temporal-sql-tool \
+      --plugin postgres12 \
+      --ep "${POSTGRES_SEEDS}" \
+      -u "${POSTGRES_USER}" \
+      -p "${DB_PORT:-5432}" \
+      --db "${database}" \
+      create
+
+    temporal-sql-tool \
+      --plugin postgres12 \
+      --ep "${POSTGRES_SEEDS}" \
+      -u "${POSTGRES_USER}" \
+      -p "${DB_PORT:-5432}" \
+      --db "${database}" \
+      setup-schema -v 0.0
+  fi
+
+  temporal-sql-tool \
+    --plugin postgres12 \
+    --ep "${POSTGRES_SEEDS}" \
+    -u "${POSTGRES_USER}" \
+    -p "${DB_PORT:-5432}" \
+    --db "${database}" \
+    update-schema -d "${schema_dir}"
+}
+
+setup_database temporal /etc/temporal/schema/postgresql/v12/temporal/versioned
+setup_database temporal_visibility /etc/temporal/schema/postgresql/v12/visibility/versioned
+
+echo "Temporal PostgreSQL schemas are ready."

--- a/infra/temporal/systemd/temporal-backup.service
+++ b/infra/temporal/systemd/temporal-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Back up Temporal PostgreSQL databases
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/temporal/scripts/backup.sh
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/infra/temporal/systemd/temporal-backup.timer
+++ b/infra/temporal/systemd/temporal-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Temporal database backup
+
+[Timer]
+OnCalendar=*-*-* 03:15:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/temporal/client_provider.py
+++ b/temporal/client_provider.py
@@ -1,50 +1,101 @@
+import base64
 import logging
 import os
+from pathlib import Path
+
 import structlog
 from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.service import TLSConfig
 
 
-async def get_temporal_client() -> Client:
+def _env_name(config_prefix: str, suffix: str) -> str:
+    return f"{config_prefix}_{suffix}"
+
+
+def _read_optional_bytes(config_prefix: str, suffix: str) -> bytes | None:
+    base64_value = os.getenv(_env_name(config_prefix, f"{suffix}_BASE64"))
+    if base64_value:
+        try:
+            normalized_value = "".join(base64_value.split())
+            return base64.b64decode(normalized_value, validate=True)
+        except ValueError as exc:
+            raise ValueError(
+                f"{_env_name(config_prefix, f'{suffix}_BASE64')} is not valid base64"
+            ) from exc
+
+    path_value = os.getenv(_env_name(config_prefix, suffix))
+    if path_value:
+        return Path(path_value).read_bytes()
+
+    return None
+
+
+def temporal_config_is_set(config_prefix: str = "TEMPORAL") -> bool:
+    """Return whether a non-default Temporal connection is configured."""
+    return bool(os.getenv(_env_name(config_prefix, "ADDRESS")))
+
+
+async def get_temporal_client(config_prefix: str = "TEMPORAL") -> Client:
+    """Connect to Temporal using API-key auth, mTLS, or local plaintext.
+
+    ``config_prefix`` is ``TEMPORAL`` for the primary cluster and
+    ``TEMPORAL_LEGACY`` for the temporary Cloud drain connection.
+    """
     logging.basicConfig(level=logging.INFO)
     logger = structlog.get_logger(__name__)
 
-    cert_path = os.getenv("TEMPORAL_TLS_CERT")
-    key_path = os.getenv("TEMPORAL_TLS_KEY")
-    api_key = os.getenv("TEMPORAL_API_KEY")
+    address_name = _env_name(config_prefix, "ADDRESS")
+    namespace_name = _env_name(config_prefix, "NAMESPACE")
+    api_key = os.getenv(_env_name(config_prefix, "API_KEY"))
+    client_cert = _read_optional_bytes(config_prefix, "TLS_CERT")
+    client_key = _read_optional_bytes(config_prefix, "TLS_KEY")
+    server_ca = _read_optional_bytes(config_prefix, "TLS_CA")
+    server_name = os.getenv(_env_name(config_prefix, "TLS_SERVER_NAME"))
 
-    # Check for mTLS authentication
-    if cert_path and key_path:
-        with open(cert_path, "rb") as f:
-            client_cert = f.read()
-        with open(key_path, "rb") as f:
-            client_key = f.read()
+    if bool(client_cert) != bool(client_key):
+        raise ValueError(
+            f"{_env_name(config_prefix, 'TLS_CERT')} and "
+            f"{_env_name(config_prefix, 'TLS_KEY')} must be configured together"
+        )
 
-        target_host=os.getenv("TEMPORAL_ADDRESS")
-        namespace=os.getenv("TEMPORAL_NAMESPACE")
-        tls=TLSConfig(
-                client_cert=client_cert,
-                client_private_key=client_key,
-            )
+    if client_cert and client_key:
+        tls: bool | TLSConfig = TLSConfig(
+            server_root_ca_cert=server_ca,
+            domain=server_name,
+            client_cert=client_cert,
+            client_private_key=client_key,
+        )
     elif api_key:
-        target_host=os.getenv("TEMPORAL_ADDRESS")
-        namespace=os.getenv("TEMPORAL_NAMESPACE")
-        tls=True
+        tls = True
     else:
-        target_host=os.getenv("TEMPORAL_ADDRESS", "localhost:7233")
-        namespace=os.getenv("TEMPORAL_NAMESPACE", "default")
-        tls = False
-      
+        tls = os.getenv(_env_name(config_prefix, "TLS"), "false").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+
+    target_host: str | None
+    namespace: str | None
+    if config_prefix == "TEMPORAL":
+        target_host = os.getenv(address_name, "localhost:7233")
+        namespace = os.getenv(namespace_name, "default")
+    else:
+        target_host = os.getenv(address_name)
+        namespace = os.getenv(namespace_name)
+
     if not target_host:
-        raise ValueError("TEMPORAL_ADDRESS environment variable is not set")
-    
+        raise ValueError(f"{address_name} environment variable is not set")
     if not namespace:
-        raise ValueError("TEMPORAL_NAMESPACE environment variable is not set")
-    
-    logger.info("temporal.client_provider.get_temporal_client.connecting_to_temporal_server",
-                 target_host=target_host, 
-                 namespace=namespace)
+        raise ValueError(f"{namespace_name} environment variable is not set")
+
+    logger.info(
+        "temporal.client_provider.connecting_to_temporal_server",
+        config_prefix=config_prefix,
+        target_host=target_host,
+        namespace=namespace,
+        authentication="mtls" if client_cert else "api_key" if api_key else "none",
+    )
 
     return await Client.connect(
         target_host,

--- a/temporal/worker.py
+++ b/temporal/worker.py
@@ -6,14 +6,18 @@ import logging
 from datetime import timedelta
 
 import structlog
+from temporalio.client import Client
 from temporalio.worker import Worker
 
-from temporal.activities.easypost.webhook_delivery_status import create_package_delivered_custom_activity_in_close_activity, update_delivery_info_for_lead_activity
+from temporal.activities.easypost.webhook_delivery_status import (
+    create_package_delivered_custom_activity_in_close_activity,
+    update_delivery_info_for_lead_activity,
+)
 
 from .activities.instantly import webhook_email_sent
 from .activities.instantly import webhook_reply_received as reply_received_activities
 from .activities.easypost import webhook_create_tracker as easypost_activities
-from temporal.client_provider import get_temporal_client
+from temporal.client_provider import get_temporal_client, temporal_config_is_set
 from temporal.shared import TASK_QUEUE_NAME
 
 from .workflows.instantly.webhook_add_lead_workflow import WebhookAddLeadWorkflow
@@ -29,64 +33,76 @@ from .workflows.easypost.webhook_create_tracker_workflow import (
     WebhookCreateTrackerWorkflow,
 )
 
-async def run_worker() -> None:
-    """Run the Temporal worker with proper configuration."""
+WORKFLOWS = [
+    WebhookEmailSentWorkflow,
+    WebhookAddLeadWorkflow,
+    WebhookReplyReceivedWorkflow,
+    WebhookCreateTrackerWorkflow,
+    WebhookDeliveryStatusWorkflow,
+]
 
-    # Configure logging
+ACTIVITIES = [
+    webhook_email_sent.complete_lead_task_by_email,
+    webhook_email_sent.add_email_activity_to_lead,
+    add_lead_to_instantly_campaign,
+    reply_received_activities.add_email_activity_to_lead,
+    reply_received_activities.pause_sequence_subscriptions,
+    reply_received_activities.send_notification_email,
+    easypost_activities.create_tracker_activity,
+    easypost_activities.update_close_lead_activity,
+    update_delivery_info_for_lead_activity,
+    create_package_delivered_custom_activity_in_close_activity,
+]
+
+
+def _build_worker(client: Client, executor: ThreadPoolExecutor) -> Worker:
+    return Worker(
+        client,
+        task_queue=TASK_QUEUE_NAME,
+        workflows=WORKFLOWS,
+        activities=ACTIVITIES,
+        graceful_shutdown_timeout=timedelta(minutes=1),
+        max_concurrent_activities=10,
+        max_concurrent_workflow_tasks=5,
+        activity_executor=executor,
+    )
+
+
+async def run_worker() -> None:
+    """Run the primary worker and, during migration, the Cloud drain worker."""
     logging.basicConfig(level=logging.INFO)
     logger = structlog.get_logger(__name__)
 
     try:
-        # Connect to Temporal server
-        client = await get_temporal_client()
+        primary_client = await get_temporal_client()
+    except Exception as exc:
+        logger.exception("failed_to_connect_to_primary_temporal_server", error=str(exc))
+        raise
 
-        logger.info("connected_to_temporal_server")
-    except Exception as e:
-        logger.error(f"Failed to connect to Temporal server: {e}")
-        logger.info("Worker will run without Temporal connection (for testing)")
-        return
+    clients: list[tuple[str, Client]] = [("primary", primary_client)]
 
-    with ThreadPoolExecutor(max_workers=10) as activity_executor:
-        # Create worker with all workflows and activities
-        worker = Worker(
-            client,
-            task_queue=TASK_QUEUE_NAME,
-            workflows=[
-                WebhookEmailSentWorkflow,
-                WebhookAddLeadWorkflow,
-                WebhookReplyReceivedWorkflow,
-                WebhookCreateTrackerWorkflow,
-                WebhookDeliveryStatusWorkflow,
-            ],
-            activities=[
-                webhook_email_sent.complete_lead_task_by_email,
-                webhook_email_sent.add_email_activity_to_lead,
-                add_lead_to_instantly_campaign,
-                reply_received_activities.add_email_activity_to_lead,
-                reply_received_activities.pause_sequence_subscriptions,
-                reply_received_activities.send_notification_email,
-                easypost_activities.create_tracker_activity,
-                easypost_activities.update_close_lead_activity,
-                update_delivery_info_for_lead_activity,
-                create_package_delivered_custom_activity_in_close_activity,
-            ],
-            # Graceful shutdown timeout
-            graceful_shutdown_timeout=timedelta(minutes=1),
-            # Activity task configuration
-            max_concurrent_activities=10,
-            max_concurrent_workflow_tasks=5,
-            activity_executor=activity_executor,
-
-        )
-
-        logger.info("Starting Temporal worker...")
+    if temporal_config_is_set("TEMPORAL_LEGACY"):
         try:
-            await worker.run()
-        except KeyboardInterrupt:
-            logger.info("Worker stopped by user")
-        except Exception as e:
-            logger.error(f"Worker failed: {e}")
+            legacy_client = await get_temporal_client("TEMPORAL_LEGACY")
+        except Exception as exc:
+            logger.exception(
+                "failed_to_connect_to_legacy_temporal_server", error=str(exc)
+            )
             raise
+        clients.append(("legacy", legacy_client))
+
+    with ThreadPoolExecutor(max_workers=10 * len(clients)) as activity_executor:
+        workers = [
+            (name, _build_worker(client, activity_executor))
+            for name, client in clients
+        ]
+
+        logger.info(
+            "starting_temporal_workers",
+            clusters=[name for name, _ in workers],
+            task_queue=TASK_QUEUE_NAME,
+        )
+        await asyncio.gather(*(worker.run() for _, worker in workers))
 
 
 if __name__ == "__main__":

--- a/tests/unit/temporal/test_client_provider.py
+++ b/tests/unit/temporal/test_client_provider.py
@@ -1,0 +1,98 @@
+import base64
+from unittest.mock import AsyncMock
+
+import pytest
+
+from temporal import client_provider
+
+
+@pytest.fixture(autouse=True)
+def clear_temporal_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    suffixes = [
+        "ADDRESS",
+        "NAMESPACE",
+        "API_KEY",
+        "TLS",
+        "TLS_CERT",
+        "TLS_CERT_BASE64",
+        "TLS_KEY",
+        "TLS_KEY_BASE64",
+        "TLS_CA",
+        "TLS_CA_BASE64",
+        "TLS_SERVER_NAME",
+    ]
+    for prefix in ("TEMPORAL", "TEMPORAL_LEGACY"):
+        for suffix in suffixes:
+            monkeypatch.delenv(f"{prefix}_{suffix}", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_local_defaults_use_plaintext(monkeypatch: pytest.MonkeyPatch) -> None:
+    connect = AsyncMock(return_value=object())
+    monkeypatch.setattr(client_provider.Client, "connect", connect)
+
+    await client_provider.get_temporal_client()
+
+    args, kwargs = connect.await_args
+    assert args == ("localhost:7233",)
+    assert kwargs["namespace"] == "default"
+    assert kwargs["api_key"] is None
+    assert kwargs["tls"] is False
+
+
+@pytest.mark.asyncio
+async def test_api_key_enables_tls(monkeypatch: pytest.MonkeyPatch) -> None:
+    connect = AsyncMock(return_value=object())
+    monkeypatch.setattr(client_provider.Client, "connect", connect)
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "cloud.example:7233")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "cloud-namespace")
+    monkeypatch.setenv("TEMPORAL_API_KEY", "secret")
+
+    await client_provider.get_temporal_client()
+
+    _, kwargs = connect.await_args
+    assert kwargs["api_key"] == "secret"
+    assert kwargs["tls"] is True
+
+
+@pytest.mark.asyncio
+async def test_base64_mtls_material_is_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    connect = AsyncMock(return_value=object())
+    monkeypatch.setattr(client_provider.Client, "connect", connect)
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "app.whiteboardgeeks.com:7233")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "mailerautomation-prod")
+    encoded_cert = base64.b64encode(b"cert").decode()
+    monkeypatch.setenv("TEMPORAL_TLS_CERT_BASE64", f"{encoded_cert[:3]}\n{encoded_cert[3:]}")
+    monkeypatch.setenv("TEMPORAL_TLS_KEY_BASE64", base64.b64encode(b"key").decode())
+    monkeypatch.setenv("TEMPORAL_TLS_CA_BASE64", base64.b64encode(b"ca").decode())
+    monkeypatch.setenv("TEMPORAL_TLS_SERVER_NAME", "app.whiteboardgeeks.com")
+
+    await client_provider.get_temporal_client()
+
+    _, kwargs = connect.await_args
+    tls = kwargs["tls"]
+    assert tls.client_cert == b"cert"
+    assert tls.client_private_key == b"key"
+    assert tls.server_root_ca_cert == b"ca"
+    assert tls.domain == "app.whiteboardgeeks.com"
+    assert kwargs["api_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_mtls_cert_and_key_are_required_together(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEMPORAL_TLS_CERT_BASE64", base64.b64encode(b"cert").decode())
+
+    with pytest.raises(ValueError, match="must be configured together"):
+        await client_provider.get_temporal_client()
+
+
+@pytest.mark.asyncio
+async def test_legacy_connection_has_no_local_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEMPORAL_LEGACY_ADDRESS", "cloud.example:7233")
+
+    with pytest.raises(ValueError, match="TEMPORAL_LEGACY_NAMESPACE"):
+        await client_provider.get_temporal_client("TEMPORAL_LEGACY")


### PR DESCRIPTION
## Summary
- deploy Temporal Server 1.31 + PostgreSQL + UI on the WBG Hetzner server
- require mTLS on the public gRPC endpoint and protect the UI with existing Google SSO
- add dual-cluster workers so new workflows use self-hosted Temporal while 126 parked Cloud workflows drain safely
- add daily verified PostgreSQL backups and operational docs

## Validation
- self-hosted prod/staging namespaces created with 30-day retention and WaitingForResume Bool search attribute
- exact Python SDK connected over mTLS; no-client-certificate connection rejected
- Temporal UI returns SSO redirect
- 5 new unit tests pass; flake8 and mypy pass
- all running containers healthy; backup service completed successfully